### PR TITLE
* handleHorizontalSlope now sets collisionState.slopeAngle, so that s…

### DIFF
--- a/Assets/CharacterController2D/CharacterController2D.cs
+++ b/Assets/CharacterController2D/CharacterController2D.cs
@@ -462,6 +462,7 @@ public class CharacterController2D : MonoBehaviour
 
 				_isGoingUpSlope = true;
 				collisionState.below = true;
+				collisionState.slopeAngle = -angle;
 			}
 		}
 		else // too steep. get out of here
@@ -560,7 +561,8 @@ public class CharacterController2D : MonoBehaviour
 				var slopeModifier = slopeSpeedMultiplier.Evaluate( -angle );
 				// we add the extra downward movement here to ensure we "stick" to the surface below
 				deltaMovement.y += _raycastHit.point.y - slopeRay.y - skinWidth;
-				deltaMovement.x *= slopeModifier;
+				deltaMovement = new Vector3( 0, deltaMovement.y, 0 ) +
+                                ( Quaternion.AngleAxis( -angle, Vector3.forward ) * new Vector3( deltaMovement.x * slopeModifier, 0, 0 ) );
 				collisionState.movingDownSlope = true;
 				collisionState.slopeAngle = angle;
 			}


### PR DESCRIPTION
…lopeAngle can be used when moving either up or down slopes. I needed this for animation purposes (#99)

* handleVerticleSlope now rotates deltaMove.x around the Z axis by the slope angle, rather then simply scaling it. This fixes a "skipping" effect that would happen when, while moving down slopes at a high speed, the controller would become ungrounded by its horizontal velocity.